### PR TITLE
Node.js 12 actions are deprecated.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: 'hotspot'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: white


### PR DESCRIPTION
Since Node.js 12 is no longer supported as of April 2022 and is deprecated, I updated Node to version 16.

Fixes #37